### PR TITLE
Fix #8: expose --const-scrollbar-overlay (user scrollbar preference)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ backwards-compatible change (semver's `1.0.0`+ rules kick in at v1).
 Only the published library (`dist/`) is versioned here; the demo and docs site
 are repo-only and not part of the npm package.
 
+## [0.7.5]
+
+### Added
+- **`head`: `--const-scrollbar-overlay`** — the user's scrollbar preference,
+  derived from the scrollbar-width probe already taken in `<head>`: `1` when
+  scrollbars overlay content (reserve no layout space, appear on interaction),
+  `0` when they're classic/inline (always shown, take up width). Lets CSS reserve
+  a gutter only when it's actually needed —
+  `padding-inline-end: calc((1 - var(--const-scrollbar-overlay)) * 12px)`. (#8)
+
 ## [0.7.4]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ heavy work, memoize it or set `gate: false` and pause internally (as `visibility
   `loaders.ts`) the first time a key needs one — so load `auto` as a module script. Tracks
   per-element keys so it only touches the delta and never clobbers imperatively-added bindings.
 - **`./head` (`src/head.ts`)** — synchronous, FOUC-safe constants for inline use in
-  `<head>`. Writes `--const-scrollbar-w`, `--const-scrollbar-thin-w`, `--const-dpr`, `--const-cores`, `--const-mem` immediately,
+  `<head>`. Writes `--const-scrollbar-w`, `--const-scrollbar-thin-w`, `--const-scrollbar-overlay`, `--const-dpr`, `--const-cores`, `--const-mem` immediately,
   **bypassing the rAF writer on purpose** (these affect first paint).
 - **`./plugins` (`src/plugins/index.ts`)** — the opt-in plugin catalog.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Bind any element with `data-props-for="key …"` and read its `--live-*` propert
 | --- | --- |
 | `prop-for-that/auto` | Zero-config & declarative: binds every `data-props-for` element — globals included, via `<html data-props-for="…">` — loading plugin sources on demand, kept in sync with the DOM. Use as `<script type="module">`. |
 | `prop-for-that` | Imperative API — `propsFor()`, `register()`, `configure()` — for explicit control and teardown. |
-| `prop-for-that/head` | Synchronous, FOUC-safe constants (scrollbar width, DPR, core count, device memory) before first paint. |
+| `prop-for-that/head` | Synchronous, FOUC-safe constants (scrollbar width & overlay preference, DPR, core count, device memory) before first paint. |
 | `prop-for-that/plugins` | The opt-in plugin catalog. |
 
 > `auto` sees the **light DOM only** (not shadow roots — bind those with `propsFor(el, …)`), and lazy-loads plugin chunks, so from a CDN use one that serves the `dist` files verbatim (unpkg / jsDelivr), not a rewriting CDN.

--- a/demos/index.html
+++ b/demos/index.html
@@ -1195,6 +1195,7 @@
               <div class="src__var" style="--val: var(--const-mem, 0); --unit: ' GiB'"><dt>--const-mem</dt><dd></dd></div>
               <div class="src__var" style="--val: var(--const-scrollbar-w, 0); --unit: 'px'"><dt>--const-scrollbar-w</dt><dd></dd></div>
               <div class="src__var" style="--val: var(--const-scrollbar-thin-w, 0); --unit: 'px'"><dt>--const-scrollbar-thin-w</dt><dd></dd></div>
+              <div class="src__var" style="--val: var(--const-scrollbar-overlay, 0)"><dt>--const-scrollbar-overlay</dt><dd></dd></div>
             </dl>
             <p class="src__desc">Write-once, FOUC-safe constants set in <code>&lt;head&gt;</code> before first paint.</p>
           </article>

--- a/demos/src/main.ts
+++ b/demos/src/main.ts
@@ -25,7 +25,7 @@ import {
   pageVisible,
   navType,
 } from 'prop-for-that/plugins'
-// FOUC-safe device constants on :root: --const-dpr / cores / mem / scrollbar-w(-thin).
+// FOUC-safe device constants on :root: --const-dpr / cores / mem / scrollbar-w(-thin) / scrollbar-overlay.
 // Side-effect import — writes once, synchronously. Surfaced in the gallery's head card.
 import 'prop-for-that/head'
 

--- a/docs/src/content/docs/start/getting-started.mdx
+++ b/docs/src/content/docs/start/getting-started.mdx
@@ -109,7 +109,7 @@ A few values are read once and matter for the first paint: scrollbar width, devi
 ```html
 <head>
   <script type="module">import 'prop-for-that/head'</script>
-  <!-- sets --const-scrollbar-w, --const-scrollbar-thin-w, --const-dpr, --const-cores, --const-mem -->
+  <!-- sets --const-scrollbar-w, --const-scrollbar-thin-w, --const-scrollbar-overlay, --const-dpr, --const-cores, --const-mem -->
 </head>
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -102,6 +102,7 @@ prefix; constants use `--const-`. Values are unitless numbers unless noted.
 | --- | --- |
 | `--const-scrollbar-w` | scrollbar width in px |
 | `--const-scrollbar-thin-w` | scrollbar width in px with `scrollbar-width: thin` (= `--const-scrollbar-w` where unsupported) |
+| `--const-scrollbar-overlay` | user's scrollbar preference: `1` = overlay (floats over content, appears on interaction, `--const-scrollbar-w` is `0`), `0` = classic/inline (always shown, reserves width) |
 | `--const-dpr` | `devicePixelRatio` |
 | `--const-cores` | `navigator.hardwareConcurrency` |
 | `--const-mem` | `navigator.deviceMemory` in GiB (Chromium-only, coarse; `0` elsewhere) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prop-for-that",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Expose what JavaScript knows but CSS can't see, as batched, diffed CSS custom properties.",
   "type": "module",
   "license": "MIT",

--- a/src/head.ts
+++ b/src/head.ts
@@ -19,7 +19,12 @@ function writeConstants(): void {
     'position:absolute;top:-9999px;width:100px;height:100px;overflow:scroll;visibility:hidden'
   const host = document.body ?? root
   host.appendChild(probe)
-  set('scrollbar-w', probe.offsetWidth - probe.clientWidth)
+  const scrollbarW = probe.offsetWidth - probe.clientWidth
+  set('scrollbar-w', scrollbarW)
+  // User's scrollbar preference, read off the same probe: overlay scrollbars
+  // reserve no layout space, so a zero width means they float over content and
+  // appear on interaction. 1 → overlay, 0 → classic/inline (always shown).
+  set('scrollbar-overlay', scrollbarW === 0 ? 1 : 0)
   probe.style.scrollbarWidth = 'thin'
   set('scrollbar-thin-w', probe.offsetWidth - probe.clientWidth)
   probe.remove()

--- a/test/head.test.ts
+++ b/test/head.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+
+/**
+ * `head` runs its probe at import time and writes the constants inline on
+ * `config.root` (documentElement). The *measurement* — does an `overflow:scroll`
+ * box reserve layout width? — is platform behaviour jsdom can't reproduce (it
+ * reports 0 for both offset/clientWidth), so that lives in the engines, not here.
+ * What we can pin in jsdom is the **derivation logic**: `--const-scrollbar-overlay`
+ * is `1` exactly when `--const-scrollbar-w` is `0`.
+ */
+describe('head: --const-scrollbar-overlay', () => {
+  it('is the boolean complement of a non-zero scrollbar width', async () => {
+    await import('../src/head')
+    const style = document.documentElement.style
+    const w = style.getPropertyValue('--const-scrollbar-w').trim()
+    const overlay = style.getPropertyValue('--const-scrollbar-overlay').trim()
+
+    expect(overlay).toBe(w === '0' ? '1' : '0')
+    // jsdom reserves no scrollbar layout space → reads as overlay.
+    expect(w).toBe('0')
+    expect(overlay).toBe('1')
+  })
+})


### PR DESCRIPTION
Overlay scrollbars reserve no layout space, so the scrollbar-width probe already taken in <head> tells us the preference directly: write --const-scrollbar-overlay as 1 when scrollbars overlay content (float, appear on interaction) and 0 when classic/inline (always shown, take up width). No new measurement — derived from the existing probe.

Closes #8.